### PR TITLE
Integrate JawsDB MySQL and Update Entity Mapping/Test Configuration

### DIFF
--- a/Project2/backend/pom.xml
+++ b/Project2/backend/pom.xml
@@ -1,86 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>org.tierlist</groupId>
-	<artifactId>project02-backend</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>project02-backend</name>
-	<description>project02-backend</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-oauth2-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><?xml version="1.0" encoding="UTF-8"?>
+	<project xmlns="http://maven.apache.org/POM/4.0.0"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		<modelVersion>4.0.0</modelVersion>
 
-		<dependency>
+		<parent>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+			<artifactId>spring-boot-starter-parent</artifactId>
+			<version>3.4.3</version>
+			<relativePath/> <!-- lookup parent from repository -->
+		</parent>
 
-	<build>
-		<plugins>
-			<plugin>
+		<groupId>org.tier-list</groupId>
+		<artifactId>project02-backend</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<name>project02-backend</name>
+		<description>project02-backend</description>
+
+		<properties>
+			<java.version>17</java.version>
+		</properties>
+
+		<dependencies>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+				<artifactId>spring-boot-starter-data-jpa</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-oauth2-client</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-security</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-web</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-devtools</artifactId>
+				<scope>runtime</scope>
+				<optional>true</optional>
+			</dependency>
+			<dependency>
+				<groupId>com.mysql</groupId>
+				<artifactId>mysql-connector-j</artifactId>
+				<scope>runtime</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-test</artifactId>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.security</groupId>
+				<artifactId>spring-security-test</artifactId>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
 
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+				</plugin>
+			</plugins>
+		</build>
+	</project>
 </project>

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/controller/TierListController.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/controller/TierListController.java
@@ -1,0 +1,28 @@
+package org.tierlist.project02backend.controller;
+
+import org.springframework.web.bind.annotation.*;
+import org.tierlist.project02backend.model.TierList;
+import org.tierlist.project02backend.service.TierListService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tierlists")
+public class TierListController {
+
+    private final TierListService tierListService;
+
+    public TierListController(TierListService tierListService) {
+        this.tierListService = tierListService;
+    }
+
+    @PostMapping
+    public TierList createTierList(@RequestBody TierList tierList) {
+        return tierListService.createTierList(tierList);
+    }
+
+    @GetMapping
+    public List<TierList> getTierLists() {
+        return tierListService.getAllTierLists();
+    }
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierList.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierList.java
@@ -1,0 +1,84 @@
+package org.tierlist.project02backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tier_lists")
+public class TierList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tier_list_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 1024)
+    private String description;
+
+    @Column(name = "is_public", nullable = false)
+    private boolean isPublic = true;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // Many TierLists can be created by one User (optional, if you want to track creator)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User creator;
+
+    public TierList() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public TierList(String title, String description, boolean isPublic, User creator) {
+        this.title = title;
+        this.description = description;
+        this.isPublic = isPublic;
+        this.creator = creator;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isPublic() {
+        return isPublic;
+    }
+
+    public void setPublic(boolean aPublic) {
+        isPublic = aPublic;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public User getCreator() {
+        return creator;
+    }
+
+    public void setCreator(User creator) {
+        this.creator = creator;
+    }
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierListItem.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierListItem.java
@@ -1,0 +1,72 @@
+package org.tierlist.project02backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tier_list_items")
+public class TierListItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "item_id")
+    private Long id;
+
+    @Column(name = "item_name", nullable = false)
+    private String itemName;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // Many items belong to one TierList
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tier_list_id", nullable = false)
+    private TierList tierList;
+
+    public TierListItem() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public TierListItem(String itemName, String imageUrl, TierList tierList) {
+        this.itemName = itemName;
+        this.imageUrl = imageUrl;
+        this.tierList = tierList;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public TierList getTierList() {
+        return tierList;
+    }
+
+    public void setTierList(TierList tierList) {
+        this.tierList = tierList;
+    }
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierListLike.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierListLike.java
@@ -1,0 +1,63 @@
+package org.tierlist.project02backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tier_list_likes",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "tier_list_id"}))
+public class TierListLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // Many likes belong to one user
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // Many likes belong to one TierList
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tier_list_id", nullable = false)
+    private TierList tierList;
+
+    public TierListLike() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public TierListLike(User user, TierList tierList) {
+        this.user = user;
+        this.tierList = tierList;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public TierList getTierList() {
+        return tierList;
+    }
+
+    public void setTierList(TierList tierList) {
+        this.tierList = tierList;
+    }
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierListRating.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/model/TierListRating.java
@@ -1,0 +1,95 @@
+package org.tierlist.project02backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tier_list_ratings",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "item_id"}))
+public class TierListRating {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rating_id")
+    private Long id;
+
+    // Define an enum to represent the rankings
+    public enum Ranking {
+        F, E, D, C, B, A, S
+    }
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Ranking ranking;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // Many ratings belong to one user
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // Many ratings belong to one TierList
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tier_list_id", nullable = false)
+    private TierList tierList;
+
+    // Many ratings belong to one TierListItem
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private TierListItem tierListItem;
+
+    public TierListRating() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public TierListRating(Ranking ranking, User user, TierList tierList, TierListItem tierListItem) {
+        this.ranking = ranking;
+        this.user = user;
+        this.tierList = tierList;
+        this.tierListItem = tierListItem;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public Ranking getRanking() {
+        return ranking;
+    }
+
+    public void setRanking(Ranking ranking) {
+        this.ranking = ranking;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public TierList getTierList() {
+        return tierList;
+    }
+
+    public void setTierList(TierList tierList) {
+        this.tierList = tierList;
+    }
+
+    public TierListItem getTierListItem() {
+        return tierListItem;
+    }
+
+    public void setTierListItem(TierListItem tierListItem) {
+        this.tierListItem = tierListItem;
+    }
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/model/User.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/model/User.java
@@ -1,0 +1,78 @@
+package org.tierlist.project02backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private String userId;
+
+    private String name;
+
+    private String email;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // Default constructor is required by JPA
+    public User() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // Convenience constructor
+    public User(String userId, String name, String email) {
+        this.userId = userId;
+        this.name = name;
+        this.email = email;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // Getters and setters
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+        setUpdatedAt(LocalDateTime.now());
+    }
+
+    // Will need changes when integrated with Oauth
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+        setUpdatedAt(LocalDateTime.now());
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/repository/TierListRepository.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/repository/TierListRepository.java
@@ -1,0 +1,8 @@
+package org.tierlist.project02backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tierlist.project02backend.model.TierList;
+
+public interface TierListRepository extends JpaRepository<TierList, Long> {
+    // Query methods (if needed) can/should be defined here
+}

--- a/Project2/backend/src/main/java/org/tierlist/project02backend/service/TierListService.java
+++ b/Project2/backend/src/main/java/org/tierlist/project02backend/service/TierListService.java
@@ -1,0 +1,25 @@
+package org.tierlist.project02backend.service;
+
+import org.springframework.stereotype.Service;
+import org.tierlist.project02backend.model.TierList;
+import org.tierlist.project02backend.repository.TierListRepository;
+
+import java.util.List;
+
+@Service
+public class TierListService {
+
+    private final TierListRepository tierListRepository;
+
+    public TierListService(TierListRepository tierListRepository) {
+        this.tierListRepository = tierListRepository;
+    }
+
+    public TierList createTierList(TierList tierList) {
+        return tierListRepository.save(tierList);
+    }
+
+    public List<TierList> getAllTierLists() {
+        return tierListRepository.findAll();
+    }
+}

--- a/Project2/backend/src/main/resources/application.properties
+++ b/Project2/backend/src/main/resources/application.properties
@@ -1,12 +1,21 @@
 spring.application.name=project02-backend
 
-# MySQL Database Connection (JawsDB on Heroku)
-spring.datasource.url=jdbc:mysql://mksq56oehykilef3:sypbttle27wc5w4r@blonze2d5mrbmcgf.cbetxkdyhwsb.us-east-1.rds.amazonaws.com:3306/ruptx61indk0bhcz
-spring.datasource.username=mksq56oehykilef3
-spring.datasource.password=sypbttle27wc5w4r
+## MySQL Database Connection (JawsDB on Heroku)
+#spring.datasource.url=jdbc:mysql:xxxx
+#spring.datasource.username=xxxx
+#spring.datasource.password=xxxx
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+
+# Raf's MySQL Database Connection (JawsDB on Heroku)
+
+# JawsDB MySQL Connection, scrubbed for git, we should use env variables
+spring.datasource.url=xxxxx
+spring.datasource.username=xxxx
+spring.datasource.password=xxxx
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# JPA Settings
-spring.jpa.hibernate.ddl-auto=none
+# JPA/Hibernate settings
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect

--- a/Project2/backend/src/test/java/org/tierlist/project02backend/TierListRepositoryTest.java
+++ b/Project2/backend/src/test/java/org/tierlist/project02backend/TierListRepositoryTest.java
@@ -1,0 +1,88 @@
+package org.tierlist.project02backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.tierlist.project02backend.model.TierList;
+import org.tierlist.project02backend.repository.TierListRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class TierListRepositoryTest {
+
+    @Autowired
+    private TierListRepository tierListRepository;
+
+    @Test
+    public void testCreateAndFindTierList() {
+        // Create a new TierList instance
+        TierList tierList = new TierList("Test Tier List", "This is a test tier list", true, null);
+        TierList savedTierList = tierListRepository.save(tierList);
+
+        // Verify that an ID was generated
+        assertThat(savedTierList.getId()).isNotNull();
+
+        // Retrieve the TierList by its id
+        Optional<TierList> fetchedOpt = tierListRepository.findById(savedTierList.getId());
+        assertThat(fetchedOpt).isPresent();
+
+        TierList fetched = fetchedOpt.get();
+        assertThat(fetched.getTitle()).isEqualTo("Test Tier List");
+        assertThat(fetched.getDescription()).isEqualTo("This is a test tier list");
+        assertThat(fetched.isPublic()).isTrue();
+    }
+
+    @Test
+    public void testUpdateTierList() {
+        // Create and save a TierList
+        TierList tierList = new TierList("Initial Title", "Initial Description", true, null);
+        TierList saved = tierListRepository.save(tierList);
+
+        // Update fields
+        saved.setTitle("Updated Title");
+        saved.setDescription("Updated Description");
+        tierListRepository.save(saved);
+
+        // Retrieve and verify changes
+        Optional<TierList> updatedOpt = tierListRepository.findById(saved.getId());
+        assertThat(updatedOpt).isPresent();
+        TierList updated = updatedOpt.get();
+        assertThat(updated.getTitle()).isEqualTo("Updated Title");
+        assertThat(updated.getDescription()).isEqualTo("Updated Description");
+    }
+
+    @Test
+    public void testDeleteTierList() {
+        // Create and save a TierList
+        TierList tierList = new TierList("To be deleted", "Delete this tier list", true, null);
+        TierList saved = tierListRepository.save(tierList);
+        Long id = saved.getId();
+
+        // Delete the TierList
+        tierListRepository.delete(saved);
+
+        // Verify it no longer exists
+        Optional<TierList> deletedOpt = tierListRepository.findById(id);
+        assertThat(deletedOpt).isNotPresent();
+    }
+
+    @Test
+    public void testFindAllTierLists() {
+        // Save multiple TierLists
+        TierList t1 = new TierList("List1", "Desc1", true, null);
+        TierList t2 = new TierList("List2", "Desc2", false, null);
+        tierListRepository.save(t1);
+        tierListRepository.save(t2);
+
+        // Retrieve all tier lists
+        List<TierList> lists = tierListRepository.findAll();
+        // Assert that at least 2 lists exist
+        assertThat(lists.size()).isGreaterThanOrEqualTo(2);
+    }
+}


### PR DESCRIPTION
Configured Spring Boot to use a remote JawsDB MySQL instance by updating application.properties with the correct JDBC URL, username, password, and MySQL8Dialect.

Updated the TierList entity to explicitly map the primary key as tier_list_id so it aligns with the generated schema.

 Changed the Hibernate DDL setting to create-drop (for development/testing) so that the schema is recreated according to our entity mappings, ensuring compatibility with JawsDB. Might nee to change this further down the line...

Adjusted the JUnit test configuration by adding @AutoCon

figureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) so tests use the remote database instead of an in-memory one.

These changes ensure our application correctly interacts with JawsDB, and that our test suite runs against the expected schema.

TestFindAllTierLists() is currently failing but I think it's just a small typo/ mismatched name, other than that DB passes all tests